### PR TITLE
Clarified the description of 'max-height' in CSS note 

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -644,7 +644,7 @@ hideInToc: true
 
 # Height Calculation
 
-- Height is calculated along the block axis(top to bottom) and default is auto(using the content inside the element) but can be set using the `height` property. The `max-height` and `min-height` properties set the maximum and minimum height of an element. `max-height` is used to prevent an element from exceeding a certain height, while `min-height` ensures that an element is at least a certain height. `min-height` is useful for creating responsive designs that adapt to different screen sizes and adjustable height. `max-height` is useful for ensuring that an element is at least a certain height, which can be helpful for maintaining the layout of a page and preventing elements from becoming too short. Height considers the content inside the element first before the parent element's height.
+- Height is calculated along the block axis(top to bottom) and default is auto(using the content inside the element) but can be set using the `height` property. The `max-height` and `min-height` properties set the maximum and minimum height of an element. `max-height` is used to prevent an element from exceeding a certain height, which can be helpful for maintaining the layout of a page and preventing elements from becoming too large. `min-height` ensures that an element is at least a certain height, making it useful for creating responsive designs that adapt to different screen sizes and ensuring adjustable height. Height considers the content inside the element first before the parent element's height.
 
 ---
 hideInToc: true


### PR DESCRIPTION
## Dear maintainers,

I have noticed that the current description of the `max-height` property in the CSS note may cause confusion, as it mistakenly states that `max-height` ensures an element is at least a certain height. This is actually the role of the `min-height` property.

### Before:
![css note](https://github.com/user-attachments/assets/4d569ee0-6360-406a-9d78-b70d73d12456)

In this pull request, I have updated the sentence to more accurately reflect the purpose of `max-height`, which is to prevent an element from exceeding a specified height, rather than ensuring a minimum height.

### After:
![CSS-Class-Note-Slidev](https://github.com/user-attachments/assets/2108add5-0eab-40f4-9b03-2621ef7df76b)

I hope this update enhances the clarity and helps future users better understand how `max-height` works. Please let me know if any further modifications are needed.

Thank you for your time and consideration.
